### PR TITLE
Support np.random.permutation with int argument.

### DIFF
--- a/hpat/_distributed.cpp
+++ b/hpat/_distributed.cpp
@@ -44,6 +44,9 @@ void oneD_reshape_shuffle(char* output,
                           int64_t old_0dim_global_len,
                           int64_t out_lower_dims_size,
                           int64_t in_lower_dims_size);
+
+void permutation_int(int64_t* output, int n);
+
 int hpat_finalize();
 int hpat_dummy_ptr[64];
 void* hpat_get_dummy_ptr() {
@@ -120,6 +123,8 @@ PyMODINIT_FUNC PyInit_hdist(void) {
                             PyLong_FromVoidPtr((void*)(&hpat_finalize)));
     PyObject_SetAttrString(m, "oneD_reshape_shuffle",
                             PyLong_FromVoidPtr((void*)(&oneD_reshape_shuffle)));
+    PyObject_SetAttrString(m, "permutation_int",
+                            PyLong_FromVoidPtr((void*)(&permutation_int)));
 
     // add actual int value to module
     PyObject_SetAttrString(m, "mpi_req_num_bytes",
@@ -455,6 +460,10 @@ int hpat_finalize()
     return 0;
 }
 
+void permutation_int(int64_t* output, int n)
+{
+     MPI_Bcast(output, n, MPI_INT64_T, 0, MPI_COMM_WORLD);
+}
 
 void oneD_reshape_shuffle(char* output,
                           char* input,

--- a/hpat/distributed.py
+++ b/hpat/distributed.py
@@ -512,6 +512,10 @@ class DistributedPass(object):
                 self._array_counts[lhs] = self._array_counts[in_arr_name]
                 self._array_sizes[lhs] = self._array_sizes[in_arr_name]
 
+        if call_list == ['permutation', 'random', np]:
+            if self.typemap[rhs.args[0].name] == types.int64:
+                return self._run_permutation_int(assign, rhs.args)
+
         # TODO: support reshape with communication
         if call_list == ['reshape']:  # A.reshape
             call_def = guard(get_definition, self.func_ir, func_var)
@@ -650,6 +654,22 @@ class DistributedPass(object):
             out[-1].target = assign.target
 
         return out
+
+    def _run_permutation_int(self, assign, args):
+        lhs = assign.target
+        n = args[0]
+
+        def f(lhs, n):
+            hpat.distributed_lower.dist_permutation_int(lhs, n)
+
+        f_block = compile_to_numba_ir(f, {'hpat': hpat},
+                                      self.typingctx,
+                                      (self.typemap[lhs.name], types.intp),
+                                      self.typemap,
+                                      self.calltypes).blocks.popitem()[1]
+        replace_arg_nodes(f_block, [lhs, n])
+        f_block.body = [assign] + f_block.body
+        return f_block.body[:-3]
 
     def _run_reshape(self, assign, in_arr, args):
         lhs = assign.target

--- a/hpat/distributed_analysis.py
+++ b/hpat/distributed_analysis.py
@@ -306,6 +306,10 @@ class DistributedAnalysis(object):
             self._analyze_call_np_concatenate(lhs, args, array_dists)
             return
 
+        if call_list == ['permutation', 'random', np]:
+            assert len(args) == 1
+            assert self.typemap[args[0].name] == types.int64
+
         # sum over the first axis is distributed, A.sum(0)
         if call_list == ['sum', np] and len(args) == 2:
             axis_def = guard(get_definition, self.func_ir, args[1])

--- a/hpat/distributed_lower.py
+++ b/hpat/distributed_lower.py
@@ -38,6 +38,7 @@ ll.add_symbol('comm_req_dealloc', hdist.comm_req_dealloc)
 ll.add_symbol('req_array_setitem', hdist.req_array_setitem)
 ll.add_symbol('hpat_dist_waitall', hdist.hpat_dist_waitall)
 ll.add_symbol('oneD_reshape_shuffle', hdist.oneD_reshape_shuffle)
+ll.add_symbol('permutation_int', hdist.permutation_int)
 
 # get size dynamically from C code
 mpi_req_llvm_type = lir.IntType(8 * hdist.mpi_req_num_bytes)
@@ -532,6 +533,11 @@ def dist_oneD_reshape_shuffle(lhs, in_arr, new_0dim_global_len, old_0dim_global_
                             dtype_size * in_lower_dims_size)
     #print(in_arr)
 
+permutation_int = types.ExternalFunction("permutation_int",
+                                         types.void(types.voidptr, types.intp))
+@numba.njit
+def dist_permutation_int(lhs, n):
+    permutation_int(lhs.ctypes, n)
 
 ########### finalize MPI when exiting ####################
 


### PR DESCRIPTION
We currently replicate the result of the call to np.random.permutation with
integer argument.  Ideally, this should be parallelized, so that each processor
generates a chunk of the permutation array.  But this patch is mostly an exercise on
how to call a C++ extension, and we leave the true parallel implementation of
permutation for future work.