### PR TITLE
Support np.random.permutation with integer argument.

### DIFF
--- a/hpat/_distributed.cpp
+++ b/hpat/_distributed.cpp
@@ -44,6 +44,9 @@ void oneD_reshape_shuffle(char* output,
                           int64_t old_0dim_global_len,
                           int64_t out_lower_dims_size,
                           int64_t in_lower_dims_size);
+
+void permutation_int(int64_t* output, int n);
+
 int hpat_finalize();
 int hpat_dummy_ptr[64];
 void* hpat_get_dummy_ptr() {
@@ -120,6 +123,8 @@ PyMODINIT_FUNC PyInit_hdist(void) {
                             PyLong_FromVoidPtr((void*)(&hpat_finalize)));
     PyObject_SetAttrString(m, "oneD_reshape_shuffle",
                             PyLong_FromVoidPtr((void*)(&oneD_reshape_shuffle)));
+    PyObject_SetAttrString(m, "permutation_int",
+                            PyLong_FromVoidPtr((void*)(&permutation_int)));
 
     // add actual int value to module
     PyObject_SetAttrString(m, "mpi_req_num_bytes",
@@ -455,6 +460,10 @@ int hpat_finalize()
     return 0;
 }
 
+void permutation_int(int64_t* output, int n)
+{
+     MPI_Bcast(output, n, MPI_INT64_T, 0, MPI_COMM_WORLD);
+}
 
 void oneD_reshape_shuffle(char* output,
                           char* input,

--- a/hpat/distributed_analysis.py
+++ b/hpat/distributed_analysis.py
@@ -306,6 +306,10 @@ class DistributedAnalysis(object):
             self._analyze_call_np_concatenate(lhs, args, array_dists)
             return
 
+        if call_list == ['permutation', 'random', np]:
+            assert len(args) == 1
+            assert self.typemap[args[0].name] == types.int64
+
         # sum over the first axis is distributed, A.sum(0)
         if call_list == ['sum', np] and len(args) == 2:
             axis_def = guard(get_definition, self.func_ir, args[1])

--- a/hpat/distributed_lower.py
+++ b/hpat/distributed_lower.py
@@ -38,6 +38,7 @@ ll.add_symbol('comm_req_dealloc', hdist.comm_req_dealloc)
 ll.add_symbol('req_array_setitem', hdist.req_array_setitem)
 ll.add_symbol('hpat_dist_waitall', hdist.hpat_dist_waitall)
 ll.add_symbol('oneD_reshape_shuffle', hdist.oneD_reshape_shuffle)
+ll.add_symbol('permutation_int', hdist.permutation_int)
 
 # get size dynamically from C code
 mpi_req_llvm_type = lir.IntType(8 * hdist.mpi_req_num_bytes)
@@ -532,6 +533,11 @@ def dist_oneD_reshape_shuffle(lhs, in_arr, new_0dim_global_len, old_0dim_global_
                             dtype_size * in_lower_dims_size)
     #print(in_arr)
 
+permutation_int = types.ExternalFunction("permutation_int",
+                                         types.void(types.voidptr, types.intp))
+@numba.njit
+def dist_permutation_int(lhs, n):
+    permutation_int(lhs.ctypes, n)
 
 ########### finalize MPI when exiting ####################
 


### PR DESCRIPTION
For now, we generate a permutation index in one processor and broadcast it to
all.  Our assumption is that the index is much smaller than the data items we
will shuffle, therefore, the cost of broadcasting an array will be negligible
compared to data shuffling.  We will support fully parallel permutation in the
future.