### PR TITLE
 Support array shuffling with an index array generated with np.random.permutation

### DIFF
--- a/hpat/_distributed.cpp
+++ b/hpat/_distributed.cpp
@@ -526,6 +526,8 @@ std::vector<int> find_recv_counts(int64_t rank, int64_t num_ranks,
     return recv_counts;
 }
 
+// Returns an |index_array| which would sort the array |v| of size |len| when
+// applied to it.  Identical to numpy.argsort.
 template<class T>
 std::vector<size_t> arg_sort(T *v, int64_t len) {
     std::vector<size_t> index_array(len);
@@ -535,6 +537,8 @@ std::vector<size_t> arg_sort(T *v, int64_t len) {
     return index_array;
 }
 
+// |v| is an array of elements of size |elem_size|.  This function swaps
+// elements located at indices |i1| and |i2|.
 void elem_swap(unsigned char *v, int64_t elem_size, size_t i1, size_t i2)
 {
     std::vector<unsigned char> tmp(elem_size);
@@ -545,6 +549,8 @@ void elem_swap(unsigned char *v, int64_t elem_size, size_t i1, size_t i2)
     std::copy(std::begin(tmp), std::end(tmp), i2_offset);
 }
 
+// Applies the permutation represented by |p| to the array |v| whose elements
+// are of size |elem_size|.
 void apply_permutation(unsigned char *v, int64_t elem_size,
                        std::vector<size_t>& p)
 {
@@ -561,6 +567,8 @@ void apply_permutation(unsigned char *v, int64_t elem_size,
     }
 }
 
+// Applies the permutation represented by |p| of size |p_len| to the array |rhs|
+// of elements of size |elem_size| and stores the result in |lhs|.
 void permutation_array_index(unsigned char *lhs, int64_t len, int64_t elem_size,
                              unsigned char *rhs, int64_t *p, int64_t p_len)
 {

--- a/hpat/_distributed.cpp
+++ b/hpat/_distributed.cpp
@@ -7,6 +7,7 @@
 #include <stdbool.h>
 #include <vector>
 #include <tuple>
+#include <random>
 
 int hpat_dist_get_rank();
 int hpat_dist_get_size();
@@ -549,6 +550,9 @@ void permutation_array_index(void *lhs, void *rhs, int64_t lhs_len,
     MPI_Alltoallv(send_buf.data(), send_counts.data(), send_disps.data(),
                   MPI_INT64_T, ilhs, recv_counts.data(), recv_disps.data(),
                   MPI_INT64_T, MPI_COMM_WORLD);
+
+    std::mt19937 rng(0);
+    std::shuffle(ilhs, ilhs + dest_ranks.size(), rng);
 }
 
 void oneD_reshape_shuffle(char* output,

--- a/hpat/_distributed.cpp
+++ b/hpat/_distributed.cpp
@@ -484,7 +484,7 @@ void permutation_int(int64_t* output, int n)
 // |num_ranks|, finds the destination ranks of indices of the |rank|.  For
 // example, if |rank| is 1, |num_ranks| is 3, |p_len| is 12, and |p| is the
 // following array [ 9, 8, 6, 4, 11, 7, 2, 3, 5, 0, 1, 10], the function returns
-// [2, 0, 1, 0].
+// [0, 2, 0, 1].
 std::vector<int64_t> find_dest_ranks(int64_t rank, int64_t num_ranks,
                                      int64_t *p, int64_t p_len)
 {
@@ -550,11 +550,11 @@ void elem_swap(unsigned char *v, int64_t elem_size, size_t i1, size_t i2)
 }
 
 // Applies the permutation represented by |p| to the array |v| whose elements
-// are of size |elem_size|.
+// are of size |elem_size| using O(1) space.  See the following URL for the
+// details: https://blogs.msdn.microsoft.com/oldnewthing/20170102-00/?p=95095.
 void apply_permutation(unsigned char *v, int64_t elem_size,
                        std::vector<size_t>& p)
 {
-    std::vector<unsigned char> tmp(elem_size);
     for (size_t i = 0; i < p.size(); ++i) {
         auto current = i;
         while (i != p[current]) {

--- a/hpat/_distributed.cpp
+++ b/hpat/_distributed.cpp
@@ -602,9 +602,23 @@ void permutation_array_index(unsigned char *lhs, int64_t len, int64_t elem_size,
                   element_t, lhs, recv_counts.data(), recv_disps.data(),
                   element_t, MPI_COMM_WORLD);
 
+    // After MPI_Alltoallv returns, we receive our chunk of data that is sorted
+    // based on their ranks.  For the global data array and the permutation
+    // array are [a b c d e f g h] and [2 7 5 6 4 3 1 0] respectively.  The
+    // shuffling of data based on the permutation is [c h f g e d b a].
+    // Assuming there are two ranks each receiving 4 data items and we are ranks
+    // 0, after MPI_Alltoallv, we receive the following chunk [c f g h] which
+    // corresponds to the sorted chunk of our permutation, that is [2 5 6 7].
+    // In order to recover the original positions of [c f g h] we first argsort
+    // the our chunk of permutation array as below:
     auto begin = p + hpat_dist_get_start(p_len, num_ranks, rank);
     auto p1 = arg_sort(begin, dest_ranks.size());
+    // The result of this argsort, which is p1, is [0 2 3 1].  This tells us how
+    // the chunk we have received is different from the target permutation we
+    // want to achieve.  Hence, to achieve the target permutation, we need to
+    // sort our data based on p1.  That is, we need to argsort p1:
     auto p2 = arg_sort(p1.data(), dest_ranks.size());
+    // which gives us [0 3 1 2], and apply this to our received data chunk.
     apply_permutation(lhs, elem_size, p2);
 
     MPI_Type_free(&element_t);

--- a/hpat/distributed.py
+++ b/hpat/distributed.py
@@ -711,7 +711,8 @@ class DistributedPass(object):
         scope, loc = lhs.scope, lhs.loc
         dtype = self.typemap[lhs.name].dtype
         out = mk_alloc(self.typemap, self.calltypes, lhs,
-                       (self._array_counts[lhs.name][0],), dtype, scope, loc)
+                       (self._array_counts[lhs.name][0],
+                        *self._array_sizes[lhs.name][1:]), dtype, scope, loc)
 
         def f(lhs, lhs_len, dtype_size, rhs, idx, idx_len):
             hpat.distributed_lower.dist_permutation_array_index(

--- a/hpat/distributed.py
+++ b/hpat/distributed.py
@@ -1155,12 +1155,13 @@ class DistributedPass(object):
                 is_multi_dim = True
 
             arr_def = guard(get_definition, self.func_ir, index_var)
-            if (arr_def.op == 'call' and
-                    self._call_table[arr_def.func.name] == ['permutation', 'random', np]):
-                self._array_starts[lhs.name] = [self._array_starts[arr.name][0]]
-                self._array_counts[lhs.name] = [self._array_counts[arr.name][0]]
-                self._array_sizes[lhs.name] = [self._array_sizes[arr.name][0]]
-                out = self._run_permutation_array_index(lhs, arr, index_var)
+            if isinstance(arr_def, ir.Expr) and arr_def.op == 'call':
+                fdef = guard(find_callname, self.func_ir, arr_def, self.typemap)
+                if fdef == ('permutation', 'numpy.random'):
+                    self._array_starts[lhs.name] = [self._array_starts[arr.name][0]]
+                    self._array_counts[lhs.name] = [self._array_counts[arr.name][0]]
+                    self._array_sizes[lhs.name] = [self._array_sizes[arr.name][0]]
+                    out = self._run_permutation_array_index(lhs, arr, index_var)
 
             # no need for transformation for whole slices
             if guard(is_whole_slice, self.typemap, self.func_ir, index_var):

--- a/hpat/distributed.py
+++ b/hpat/distributed.py
@@ -702,7 +702,7 @@ class DistributedPass(object):
     def _run_permutation_array_index(self, lhs, rhs, idx):
         scope, loc = lhs.scope, lhs.loc
         alloc = mk_alloc(self.typemap, self.calltypes, lhs,
-                         tuple(self._array_sizes[lhs.name]),
+                         (self._array_counts[lhs.name][0],),
                          self.typemap[lhs.name].dtype, scope, loc)
 
         def f(lhs, rhs, lhs_len, idx, idx_len):
@@ -1158,9 +1158,9 @@ class DistributedPass(object):
             if isinstance(arr_def, ir.Expr) and arr_def.op == 'call':
                 fdef = guard(find_callname, self.func_ir, arr_def, self.typemap)
                 if fdef == ('permutation', 'numpy.random'):
-                    self._array_starts[lhs.name] = [self._array_starts[arr.name][0]]
-                    self._array_counts[lhs.name] = [self._array_counts[arr.name][0]]
-                    self._array_sizes[lhs.name] = [self._array_sizes[arr.name][0]]
+                    self._array_starts[lhs.name] = self._array_starts[arr.name]
+                    self._array_counts[lhs.name] = self._array_counts[arr.name]
+                    self._array_sizes[lhs.name] = self._array_sizes[arr.name]
                     out = self._run_permutation_array_index(lhs, arr, index_var)
 
             # no need for transformation for whole slices

--- a/hpat/distributed_analysis.py
+++ b/hpat/distributed_analysis.py
@@ -230,10 +230,6 @@ class DistributedAnalysis(object):
             self._analyze_call_hpat_dist(lhs, func_name, args, array_dists)
             return
 
-        if fdef == ('permutation', 'numpy.random'):
-            assert len(args) == 1
-            assert self.typemap[args[0].name] == types.int64
-
         # len()
         if func_name == 'len' and func_mod in ('__builtin__', 'builtins'):
             return

--- a/hpat/distributed_analysis.py
+++ b/hpat/distributed_analysis.py
@@ -518,6 +518,14 @@ class DistributedAnalysis(object):
                                                 new_dist.value))
             return
 
+        # array selection with permutation array index
+        if is_np_array(self.typemap, index_var.name):
+            arr_def = guard(get_definition, self.func_ir, index_var)
+            if (arr_def.op == 'call' and
+                    self._call_table[arr_def.func.name] == ['permutation', 'random', np]):
+                self._meet_array_dists(lhs, rhs.value.name, array_dists)
+                return
+
         # whole slice or strided slice access
         # for example: A = X[:,5], A = X[::2,5]
         if guard(is_whole_slice, self.typemap, self.func_ir, index_var,

--- a/hpat/distributed_lower.py
+++ b/hpat/distributed_lower.py
@@ -39,6 +39,7 @@ ll.add_symbol('req_array_setitem', hdist.req_array_setitem)
 ll.add_symbol('hpat_dist_waitall', hdist.hpat_dist_waitall)
 ll.add_symbol('oneD_reshape_shuffle', hdist.oneD_reshape_shuffle)
 ll.add_symbol('permutation_int', hdist.permutation_int)
+ll.add_symbol('permutation_array_index', hdist.permutation_array_index)
 
 # get size dynamically from C code
 mpi_req_llvm_type = lir.IntType(8 * hdist.mpi_req_num_bytes)
@@ -539,6 +540,17 @@ permutation_int = types.ExternalFunction("permutation_int",
 @numba.njit
 def dist_permutation_int(lhs, n):
     permutation_int(lhs.ctypes, n)
+
+permutation_array_index = types.ExternalFunction("permutation_array_index",
+                                                 types.void(types.voidptr,
+                                                            types.voidptr,
+                                                            types.intp,
+                                                            types.voidptr,
+                                                            types.intp))
+@numba.njit
+def dist_permutation_array_index(lhs, rhs, lhs_len, idx, idx_len):
+    permutation_array_index(
+        lhs.ctypes, rhs.ctypes, lhs_len, idx.ctypes, idx_len)
 
 ########### finalize MPI when exiting ####################
 

--- a/hpat/distributed_lower.py
+++ b/hpat/distributed_lower.py
@@ -549,9 +549,11 @@ permutation_array_index = types.ExternalFunction("permutation_array_index",
                                                             types.voidptr,
                                                             types.intp))
 @numba.njit
-def dist_permutation_array_index(lhs, lhs_len, lhs_elem_size, rhs,
-                                 p, p_len):
-    permutation_array_index(lhs.ctypes, lhs_len, lhs_elem_size, rhs.ctypes,
+def dist_permutation_array_index(lhs, lhs_len, dtype_size, rhs, p, p_len):
+    c_rhs = np.ascontiguousarray(rhs)
+    lower_dims_size = get_tuple_prod(c_rhs.shape[1:])
+    elem_size = dtype_size * lower_dims_size
+    permutation_array_index(lhs.ctypes, lhs_len, elem_size, c_rhs.ctypes,
                             p.ctypes, p_len)
 
 ########### finalize MPI when exiting ####################

--- a/hpat/distributed_lower.py
+++ b/hpat/distributed_lower.py
@@ -543,14 +543,16 @@ def dist_permutation_int(lhs, n):
 
 permutation_array_index = types.ExternalFunction("permutation_array_index",
                                                  types.void(types.voidptr,
-                                                            types.voidptr,
                                                             types.intp,
+                                                            types.intp,
+                                                            types.voidptr,
                                                             types.voidptr,
                                                             types.intp))
 @numba.njit
-def dist_permutation_array_index(lhs, rhs, lhs_len, idx, idx_len):
-    permutation_array_index(
-        lhs.ctypes, rhs.ctypes, lhs_len, idx.ctypes, idx_len)
+def dist_permutation_array_index(lhs, lhs_len, lhs_elem_size, rhs,
+                                 p, p_len):
+    permutation_array_index(lhs.ctypes, lhs_len, lhs_elem_size, rhs.ctypes,
+                            p.ctypes, p_len)
 
 ########### finalize MPI when exiting ####################
 

--- a/hpat/tests/test_basic.py
+++ b/hpat/tests/test_basic.py
@@ -264,5 +264,16 @@ class TestBasic(unittest.TestCase):
         self.assertEqual(count_array_REPs(), 0)
         self.assertEqual(count_parfor_REPs(), 0)
 
+    def test_permuted_array_indexing(self):
+        def test_impl(n):
+            A = np.arange(n)
+            B = np.random.permutation(n)
+            A = A[B]
+            return A.sum()
+
+        hpat_func = hpat.jit(test_impl)
+        for n in [11, 111, 128, 120]:
+            np.testing.assert_allclose(hpat_func(n), test_impl(n))
+
 if __name__ == "__main__":
     unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,8 @@ ext_hdist = Extension(name="hdist",
                              libraries = MPI_LIBS,
                              sources=["hpat/_distributed.cpp"],
                              include_dirs=[PREFIX_DIR+'/include/'],
+                             extra_compile_args=['-std=c++11'],
+                             extra_link_args=['-std=c++11'],
                              )
 
 ext_chiframes = Extension(name="chiframes",


### PR DESCRIPTION
Currently, it assumes the array that is being indexed is a one-dimensional array of ints and appears to work.  Please see if this makes sense.  If it does, then I will extend it to support multi-dimensional arrays.