### PR TITLE
report complex128 result type for Series corr and cov methods

### DIFF
--- a/hpat/pd_series_ext.py
+++ b/hpat/pd_series_ext.py
@@ -417,23 +417,22 @@ class SeriesAttribute(AttributeTemplate):
         ret_typ = if_arr_to_series_type(ret_typ)
         return signature(ret_typ, *args)
 
-    @bound_function("series.cov")
-    def resolve_cov(self, ary, args, kws):
+    def _resolve_cov_func(self, ary, args, kws):
         # array is valid since hiframes_typed calls this after type replacement
         assert len(args) == 1 and isinstance(args[0], (SeriesType, types.Array))
         assert isinstance(ary.dtype, types.Number)
         assert isinstance(args[0].dtype, types.Number)
-        ret_typ = types.complex128 if isinstance(args[0].dtype, types.Complex) else types.float64
+        is_complex_op = isinstance(ary.dtype, types.Complex) or isinstance(args[0].dtype, types.Complex)
+        ret_typ = types.complex128 if is_complex_op else types.float64
         return signature(ret_typ, *args)
+
+    @bound_function("series.cov")
+    def resolve_cov(self, ary, args, kws):
+        return self._resolve_cov_func(ary, args, kws)
 
     @bound_function("series.corr")
     def resolve_corr(self, ary, args, kws):
-        # array is valid since hiframes_typed calls this after type replacement
-        assert len(args) == 1 and isinstance(args[0], (SeriesType, types.Array))
-        assert isinstance(ary.dtype, types.Number)
-        assert isinstance(args[0].dtype, types.Number)
-        ret_typ = types.complex128 if isinstance(args[0].dtype, types.Complex) else types.float64
-        return signature(ret_typ, *args)
+        return self._resolve_cov_func(ary, args, kws)
 
     @bound_function("series.append")
     def resolve_append(self, ary, args, kws):

--- a/hpat/pd_series_ext.py
+++ b/hpat/pd_series_ext.py
@@ -423,8 +423,8 @@ class SeriesAttribute(AttributeTemplate):
         assert len(args) == 1 and isinstance(args[0], (SeriesType, types.Array))
         assert isinstance(ary.dtype, types.Number)
         assert isinstance(args[0].dtype, types.Number)
-        # TODO: complex numbers return complex
-        return signature(types.float64, *args)
+        ret_typ = types.complex128 if isinstance(args[0].dtype, types.Complex) else types.float64
+        return signature(ret_typ, *args)
 
     @bound_function("series.corr")
     def resolve_corr(self, ary, args, kws):
@@ -432,8 +432,8 @@ class SeriesAttribute(AttributeTemplate):
         assert len(args) == 1 and isinstance(args[0], (SeriesType, types.Array))
         assert isinstance(ary.dtype, types.Number)
         assert isinstance(args[0].dtype, types.Number)
-        # TODO: complex numbers return complex
-        return signature(types.float64, *args)
+        ret_typ = types.complex128 if isinstance(args[0].dtype, types.Complex) else types.float64
+        return signature(ret_typ, *args)
 
     @bound_function("series.append")
     def resolve_append(self, ary, args, kws):

--- a/hpat/tests/test_series.py
+++ b/hpat/tests/test_series.py
@@ -547,6 +547,10 @@ class TestSeries(unittest.TestCase):
         S1 = pd.Series([np.nan, -2., 3., 9.1])
         S2 = pd.Series([np.nan, -2., 3., 5.0])
         np.testing.assert_almost_equal(hpat_func(S1, S2), test_impl(S1, S2))
+        complex_S1 = pd.Series([complex(-2., 1.), complex(3., 1.)])
+        complex_S2 = pd.Series([complex(-2., 1.), complex(3., 1.)])
+        # TODO(quasilyte): more intricate data for complex-typed series.
+        np.testing.assert_almost_equal(hpat_func(complex_S1, complex_S2), test_impl(complex_S1, complex_S2))
 
     def test_series_corr1(self):
         def test_impl(S1, S2):
@@ -556,6 +560,11 @@ class TestSeries(unittest.TestCase):
         S1 = pd.Series([np.nan, -2., 3., 9.1])
         S2 = pd.Series([np.nan, -2., 3., 5.0])
         np.testing.assert_almost_equal(hpat_func(S1, S2), test_impl(S1, S2))
+        complex_S1 = pd.Series([complex(-2., 1.), complex(3., 1.)])
+        complex_S2 = pd.Series([complex(-2., 1.), complex(3., 1.)])
+        # TODO(quasilyte): more intricate data for complex-typed series when _column_corr_impl
+        # is fixed and returns "almost equal" results to np.corrcoef.
+        np.testing.assert_almost_equal(hpat_func(complex_S1, complex_S2), test_impl(complex_S1, complex_S2))
 
     def test_series_str_len1(self):
         def test_impl(S):


### PR DESCRIPTION
For complex input arguments, return complex type.
For all other types, return float64.

Added test cases that were previously unsupported due to typecheck errors from numba.
There are precision problems for some other input data, but this is unrelated issue and should be
addressed separately (if at all, I don't know the requirements).