### PR TITLE
hiframes: better error reporting for getattr

### DIFF
--- a/hpat/hiframes.py
+++ b/hpat/hiframes.py
@@ -93,6 +93,7 @@ df_spec = {
         'ndim',
     ],
     DataFrameAttr.UNIMPLEMENTED_METHOD: [
+        'filter',
     ],
     DataFrameAttr.IMPLEMENTED_ATTR: [
         'values',

--- a/hpat/hiframes.py
+++ b/hpat/hiframes.py
@@ -88,39 +88,43 @@ def remove_hiframes(rhs, lives, call_list):
 
 # TODO(quasilyte): remove duplication from this dict and
 # methods handling specific attributes and methods.
-df_spec = {}
-unimplemented_attrs = [
-    'ndim',
-]
-unimplemented_methods = []
-implemented_attrs = [
-    'values',
-    'iat',
-    'loc',
-    'iloc',
-]
-implemented_methods = [
-    'apply',
-    'describe',
-    'sort_values',
-    'itertuples',
-    'pivot_table',
-    'head',
-    'isin',
-    'append',
-    'fillna',
-    'dropna',
-    'groupby',
-    'rolling',
-]
-for name in unimplemented_attrs:
-    df_spec[name] = DataFrameAttr.UNIMPLEMENTED_ATTR
-for name in unimplemented_methods:
-    df_spec[name] = DataFrameAttr.UNIMPLEMENTED_METHOD
-for name in implemented_attrs:
-    df_spec[name] = DataFrameAttr.IMPLEMENTED_ATTR
-for name in implemented_methods:
-    df_spec[name] = DataFrameAttr.IMPLEMENTED_METHOD
+df_spec = {
+    DataFrameAttr.UNIMPLEMENTED_ATTR: [
+        'ndim',
+    ],
+    DataFrameAttr.UNIMPLEMENTED_METHOD: [
+    ],
+    DataFrameAttr.IMPLEMENTED_ATTR: [
+        'values',
+        'iat',
+        'loc',
+        'iloc',
+    ],
+    DataFrameAttr.IMPLEMENTED_METHOD: [
+        'apply',
+        'describe',
+        'sort_values',
+        'itertuples',
+        'pivot_table',
+        'head',
+        'isin',
+        'append',
+        'fillna',
+        'dropna',
+        'groupby',
+        'rolling',
+    ],
+}
+
+# To avoid excessive globals and keep convenient inversed dict literal,
+# convert to final form using comprehensions.
+# First comprehension turns dict into a list of dicts.
+# Second comprehension merges all dicts together.
+# {0: ['a', 'b'], 1: ['c']}
+# => [{'a': 0, 'b': 0}, {'c': 1}]
+# => {'a': 0, 'b': 0, 'c': 1}
+df_spec = [{v:k for v in values} for k, values in df_spec.items()]
+df_spec = {k:v for d in df_spec for k, v in d.items()}
 
 numba.ir_utils.remove_call_handlers.append(remove_hiframes)
 

--- a/hpat/tests/test_errors.py
+++ b/hpat/tests/test_errors.py
@@ -1,0 +1,38 @@
+import unittest
+import pandas as pd
+import numpy as np
+import hpat
+import warnings
+
+class TestDataFrameErrors(unittest.TestCase):
+    def test_get_unknown_attr(self):
+        def test_impl():
+            df = pd.DataFrame({'A': [0, 0]})
+            A = df['A'] # OK, known column
+            field = df.loc # OK, known field
+            method = df.apply # OK, known method
+            something = df.non_existing # Should warn
+
+        with warnings.catch_warnings(record=True) as w:
+            hpat.jit(test_impl)()
+            self.assertIn(
+                "unknown attribute df.non_existing accessed",
+                str(w[0].message))
+
+    def test_get_unimplemented_attr(self):
+        def test_impl():
+            df = pd.DataFrame({'A': [1.0, 2.0]})
+            ndim = df.ndim
+
+        with self.assertRaises(NotImplementedError) as err:
+            hpat.jit(test_impl)()
+        self.assertIn("data frame attribute ndim not implemented yet", str(err.exception))
+
+    def test_call_unimplemented_method(self):
+        def test_impl():
+            df = pd.DataFrame({'A': [0.1, 0.2], 'B': [0.3]})
+            return df.filter(items=['A'])
+
+        with self.assertRaises(NotImplementedError) as err:
+            hpat.jit(test_impl)()
+        self.assertIn("data frame function filter not implemented yet", str(err.exception))


### PR DESCRIPTION
- Report bound instancemethod references that were not
  immediately invoked (see #63)
- Report undefined (unknown) data frame attributes access

TODO: fill "unimplemented" lists, so HPAT can report
"unimplemented yet" instead of "unknown attribute".

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>