### PR TITLE
fixing typing for InlineClosureCallPass

### DIFF
--- a/hpat/compiler.py
+++ b/hpat/compiler.py
@@ -221,7 +221,7 @@ class HPATPipeline(numba.compiler.BasePipeline):
     def stage_repeat_inline_closure(self):
         assert self.func_ir
         inline_pass = InlineClosureCallPass(
-            self.func_ir, self.flags.auto_parallel)
+            self.func_ir, self.flags.auto_parallel, typed=True)
         inline_pass.run()
         post_proc = postproc.PostProcessor(self.func_ir)
         post_proc.run()


### PR DESCRIPTION
We recently detected integration testing failures with the latest Numba
master and the latest released version of HPAT.

Specifically, the following error was raised:

```
======================================================================
FAIL: test_kmeans (hpat.tests.test_ml.TestML)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/circleci/repo/miniconda3/envs/hpat/lib/python3.6/site-packages/hpat/tests/test_ml.py", line 110, in test_kmeans
    self.assertEqual(count_array_OneDs(), 4)
AssertionError: 0 != 4
```

A CI build log can be found here:

https://circleci.com/gh/numba/numba-integration-testing/24

Using `git bisect` the following offending commit was detected in the
Numba Git history:

`e5d8a41e15d4bbb7f2b81859dab210c9abdf8ccc is the first bad commit`

And this was then traced to the following pull-request:

https://github.com/numba/numba/pull/3884

The problem here is, that `InlineClosureCallPass` was equipped with a new
keyword argument `typed` which defaults to `False` bzut should be `True`
in this case.

This patch fixes that and makes the test-suite pass once again.